### PR TITLE
[BUG-2] Fix error when clearing data

### DIFF
--- a/src/models/PokemonModels.js
+++ b/src/models/PokemonModels.js
@@ -14,7 +14,12 @@ export default {
   },
   reducers: {
     addData(prevState, data) {
-      const updatedData = [...prevState.data, data];
+      let updatedData;
+      if (prevState.data) {
+        updatedData = [...prevState.data, data];
+      } else {
+        updatedData = [data];
+      }
       localStorage.setItem("pokemonData", JSON.stringify(updatedData));
       return {
         ...prevState,


### PR DESCRIPTION
What's Happen
-----
![Screen Shot 2019-12-15 at 14 13 30](https://user-images.githubusercontent.com/57338415/70859454-586e0b00-1f46-11ea-9701-9b9deaacdd23.png)

When this occurs
-----
When user pressing button `Clear Data` and then try to catch another pokemon, then this error message will show up. This is happens because there is no checking if the prevState.data becoming null and we force that to be in [...prevState.data, data], so it will show this error.